### PR TITLE
Mute "Série A" (Brazil) league, and tune down logging

### DIFF
--- a/heroku-config.edn
+++ b/heroku-config.edn
@@ -24,5 +24,5 @@
   }
   :default-league-channel-id "710316975393341511"       ; League Discussions > #other
 
-  :muted-leagues ["Championship"]
+  :muted-leagues ["Championship" "Série A"]
 }

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -26,8 +26,8 @@
   <logger name="org.apache"  level="ERROR" />
   <logger name="org.eclipse" level="ERROR" />
   <logger name="org.jolokia" level="ERROR" />
-  <logger name="discljord"   level="WARN" />
-  <logger name="futbot"      level="DEBUG" />
+  <logger name="discljord"   level="ERROR" />
+  <logger name="futbot"      level="INFO" />
 
   <root level="INFO">
     <appender-ref ref="STDOUT" />

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -25,7 +25,6 @@
 
   <logger name="org.apache"  level="ERROR" />
   <logger name="org.eclipse" level="ERROR" />
-  <logger name="org.jolokia" level="ERROR" />
   <logger name="discljord"   level="ERROR" />
   <logger name="futbot"      level="INFO" />
 

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -29,7 +29,7 @@
   <logger name="discljord"   level="ERROR" />
   <logger name="futbot"      level="INFO" />
 
-  <root level="INFO">
+  <root level="WARN">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
- Mute the "Série A" league from Brazil (since we don't have any Brazilian referees in the server yet).
- Tune down logging, to reduce spurious log output in production.