### PR TITLE
:new: Fixes issue 114

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -35,6 +35,7 @@
         clj-pdf/clj-pdf                     {:mvn/version "2.5.5"}
         rm-hull/markov-chains               {:mvn/version "0.1.1"}
         remus/remus                         {:mvn/version "0.2.1"}
+        org.jsoup/jsoup                     {:mvn/version "1.13.1"}
        }
  :aliases
    {; clj -M:run -c /path/to/config.edn

--- a/src/futbot/cnra.clj
+++ b/src/futbot/cnra.clj
@@ -1,0 +1,56 @@
+;
+; Copyright © 2020 Peter Monks
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+;
+; SPDX-License-Identifier: Apache-2.0
+;
+
+(ns futbot.cnra
+  (:require [clojure.string :as s]
+            [java-time      :as tm]
+            [remus          :as rss]
+            [futbot.util    :as u]))
+
+(def cnra-rss-feed-url "http://www.cnra.net/feed/atom/")   ; I prefer atom...
+(def quiz-post-title   "Monthly Video Quizzes")
+
+(defn para-to-quiz
+  [^org.jsoup.nodes.Element p]
+  (let [text               (u/replace-all (.text p)
+                                         [[#"[–‑‒–—]" "-"]])  ; Normalise Unicode "dash" characters
+       [month-year topic] (s/split text #" - ")   ; NOTE: ASSUMES QUIZ LINK PARAS ARE CONSISTENT - NEED TO CONFIRM ON NOV 15 WHEN THEY PUBLISH A SECOND ONE!
+       date               (tm/local-date "dd MMMM yyyy" (str "15 " month-year))
+       link               (.attr (.selectFirst p "a[href*=forms.gle]") "href")]      ; Note: assumes the quiz is always the first link to a Google form
+    (when link
+      {
+        :date  date
+        :topic (s/lower-case topic)
+        :link  link
+      })))
+
+(defn html-to-quizzes
+  [html]
+  (let [quiz-paras (drop-last (drop 2 (.select (org.jsoup.Jsoup/parse html) "p")))]   ; NOTE: ASSUMES PAGE STRUCTURE STAYS CONSISTENT - NEED TO CONFIRM ON NOV 15 WHEN THEY PUBLISH A SECOND ONE!
+    (keep identity (map para-to-quiz quiz-paras))))
+
+(defn quizzes
+  "Returns a sequence of maps representing all of the video quizzes posted by CNRA, optionally since the given date, or nil if there aren't any."
+  ([] (quizzes nil))
+  ([since]
+    (seq
+      (when-let [all-quizzes (html-to-quizzes (:value (first (:contents (first (filter #(= (:title %) quiz-post-title)
+                                                                                       (:entries (:feed (rss/parse-url cnra-rss-feed-url)))))))))]
+        (if since
+          (filter #(tm/after? (:date %) since) all-quizzes)
+          all-quizzes)))))

--- a/src/futbot/jobs.clj
+++ b/src/futbot/jobs.clj
@@ -25,6 +25,7 @@
             [discljord.messaging       :as dm]
             [futbot.football-data      :as fd]
             [futbot.dutch-referee-blog :as drb]
+            [futbot.cnra               :as cnra]
             [futbot.pdf                :as pdf]
             [futbot.flags              :as fl]))
 
@@ -185,4 +186,19 @@
          @(dm/create-reaction! discord-message-channel channel-id message-id "4️⃣")
          @(dm/create-reaction! discord-message-channel channel-id message-id "5️⃣"))
        nil)
-     (log/info "No new quizzes found"))))
+     (log/info "No new Dutch referee blog quizzes found"))))
+
+(defn check-for-new-cnra-quiz-and-post-to-channel!
+  "Checks whether a new CNRA quiz has been posted since the first of the month, and posts it to the given channel if so."
+  [discord-message-channel channel-id]
+  (if-let [new-quizzes (cnra/quizzes (tm/adjust (tm/local-date) :first-day-of-month))]
+    (let [message    (str "<:cnra:769311341751959562> A new **CNRA Quiz** has been posted, on the topic of **"
+                          (:topic (first new-quizzes))
+                          "**: "
+                          (:link (first new-quizzes))
+                          "\nPuzzled by an answer? React or comment and we can discuss!")]
+      (dm/create-message! discord-message-channel
+                          channel-id
+                          :content message)
+      nil)
+    (log/info "No new CNRA quizzes found")))


### PR DESCRIPTION
Addresses issue #114 

Summary of changes:

* Add ns for querying CNRA blog and retrieving list of quizzes. **NOTE: further testing required after the second quiz is posted on November 15th!**
* Add monthly job to check for a new CNRA quiz and post it to the appropriate channel in Discord
* Minor tweak to Dutch Referee Blog quiz, so that it runs in its local timezone (Europe/Amsterdam) rather than UTC

Head's up @pmonks!