### PR TITLE
Update to new CNRA quiz URL, and enable proper SSL client

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -71,6 +71,12 @@
                                      :sha     "cd1f25456de5eebda0a69602dd3445905382b3a4"}}
        :main-opts  ["-m" "clj-check.check"]}
 
+
+    ; clj -M:kondo
+    :kondo
+      {:extra-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}
+       :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "resources"]}
+
     ; clj -M:eastwood
     :eastwood
       {:extra-deps {jonase/eastwood {:mvn/version "0.3.12"}}

--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,7 @@
     mount/mount                         {:mvn/version "0.1.16"}
     jarohen/chime                       {:mvn/version "0.3.2"}
     org.suskalo/discljord               {:mvn/version "1.2.0"}
-    http-kit/http-kit                   {:mvn/version "2.5.0"}
+    http-kit/http-kit                   {:mvn/version "2.5.1"}
     cheshire/cheshire                   {:mvn/version "5.10.0"}
     clj-pdf/clj-pdf                     {:mvn/version "2.5.5"}
     rm-hull/markov-chains               {:mvn/version "0.1.1"}

--- a/src/futbot/config.clj
+++ b/src/futbot/config.clj
@@ -17,18 +17,19 @@
 ;
 
 (ns futbot.config
-  (:require [clojure.java.io       :as io]
-            [clojure.string        :as s]
-            [clojure.tools.logging :as log]
-            [clojure.edn           :as edn]
-            [clojure.core.async    :as async]
-            [java-time             :as tm]
-            [aero.core             :as a]
-            [mount.core            :as mnt :refer [defstate]]
-            [discljord.connections :as dc]
-            [discljord.messaging   :as dm]
-            [futbot.util           :as u]
-            [futbot.source.youtube :as yt]))
+  (:require [clojure.java.io        :as io]
+            [clojure.string         :as s]
+            [clojure.tools.logging  :as log]
+            [clojure.edn            :as edn]
+            [clojure.core.async     :as async]
+            [java-time              :as tm]
+            [aero.core              :as a]
+            [mount.core             :as mnt :refer [defstate]]
+            [org.httpkit.sni-client :as sni-client]
+            [discljord.connections  :as dc]
+            [discljord.messaging    :as dm]
+            [futbot.util            :as u]
+            [futbot.source.youtube  :as yt]))
 
 ; Because java.util.logging is a hot mess
 (org.slf4j.bridge.SLF4JBridgeHandler/removeHandlersForRootLogger)
@@ -39,6 +40,9 @@
  (reify Thread$UncaughtExceptionHandler
    (uncaughtException [_ t e]
      (u/log-exception e (str "Uncaught exception on " (.getName t))))))
+
+; See https://github.com/http-kit/http-kit#enabling-client-sni-support-disabled-by-default
+(alter-var-root #'org.httpkit.client/*default-client* (fn [_] sni-client/default-client))
 
 (def boot-time (tm/instant))
 

--- a/src/futbot/source/cnra.clj
+++ b/src/futbot/source/cnra.clj
@@ -22,7 +22,7 @@
             [org.httpkit.client :as http]
             [futbot.util        :as u]))
 
-(def cnra-quiz-page-url "http://www.cnra.net/monthly-video-quizzes/")
+(def cnra-quiz-page-url "https://www.cnra.net/monthly-video-quizzes/")
 
 (defn- retrieve-and-parse-quiz-page
   "Retrieves the CNRA quiz page and returns a JSoup-parsed represention. Throws an ex-info on failure."


### PR DESCRIPTION
Summary of changes:

* Add clj-kondo to aliases
* Upgrade dependency (http-kit)
* Update to new CNRA quiz URL, and enable proper SSL client
